### PR TITLE
feat: add data-id in image attribute

### DIFF
--- a/src/content-processor/markdown-process.js
+++ b/src/content-processor/markdown-process.js
@@ -139,15 +139,15 @@ const markedProcessorFactory = ({
           // For HTML render
           const imageId = token.href.split('/').pop();
           const imageExt = window.contentConfig.images[imageId];
-          return `<img src="./images/${imageExt}" alt="${token.text}">`;
+          return `<img src="./images/${imageExt}" alt="${token.text}" data-id="${imageId}">`;
         }
         // For editor preview
         const imageFile = imageFiles[token.href];
         const blobUrl = blobUrlManager(token.href, imageFile);
-        return `<img src="${blobUrl}" alt="${token.text}">`;
+        return `<img src="${blobUrl}" alt="${token.text}" data-id="${token.href}">`;
       } catch (error) {
         console.error('Error processing image:', error);
-        return `<img src="${token.href}" alt="${token.text}">`;
+        return `<img src="${token.href}" alt="${token.text}" data-id="${token.href}">`;
       }
     },
   };


### PR DESCRIPTION
Add `data-id` in `img` to support [#PR65](https://github.com/coseeing/Access8MathWeb/pull/65).