### PR TITLE
fix(ci): add GitHub Packages authentication to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Authenticate with github package registry
+        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
## Why

Publish workflow 在執行 `npm publish` 時缺少 GitHub Packages registry 的認證設定，導致沒有權限下載 nemeth2latex 套件，而發佈失敗。