### PR TITLE
fix(ci): fix GitHub Packages auth and upgrade CI to Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@coseeing'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Authenticate with github package registry
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
-
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@coseeing'
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run ESLint lint
         run: npm run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Authenticate with github package registry
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
-
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -22,6 +19,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run ESLint lint
         run: npm run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@coseeing'
 


### PR DESCRIPTION
## 背景描述 (Why)

Publish workflow 的 `npm ci` 步驟在安裝 `@coseeing/nemeth2latex` 時出現 401 Unauthorized。原因是 `actions/setup-node` 設定 `registry-url` 後會建立自己的 `.npmrc`（透過`NPM_CONFIG_USERCONFIG` 指向 `/home/runner/work/_temp/.npmrc`），完全覆蓋前一步手動寫入 `~/.npmrc` 的 auth token。該 `.npmrc` 使用 `NODE_AUTH_TOKEN` 環境變數認證，但 `npm ci` 步驟沒有設定這個變數。

另外 GitHub Actions 已發出 Node.js 20 deprecation 警告，2026-06-02 起將強制使用 Node.js 24 runtime，且 Node.js 20 本身已 EOL。

## 實作方法 (How)

- 移除手動寫 `~/.npmrc` 的步驟（會被 `setup-node` 覆蓋，無效）
- 在 `npm ci` 步驟加上 `NODE_AUTH_TOKEN` 環境變數，讓 `setup-node` 產生的 `.npmrc` 能正確認證
- CI workflow 也加上 `registry-url` 和 `scope` 設定，統一兩個 workflow 的認證方式
- 升級 `actions/checkout` 和 `actions/setup-node` 從 v4 到 v5
- Node.js runtime 從 20 升級到 22 LTS
