### PR TITLE
fix: correct paragraph wrapping for inline link extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coseeing/see-mark",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A markdown parser for a11y",
   "main": "./lib/see-mark.cjs",
   "files": [

--- a/src/markdown-processor/marked-extentions/external-link-tab-title.js
+++ b/src/markdown-processor/marked-extentions/external-link-tab-title.js
@@ -54,7 +54,10 @@ const markedExternalLinkTabTitle = () => {
           }
         },
         renderer: createRenderer(
-          SUPPORTED_COMPONENT_TYPES.EXTERNAL_LINK_TAB_TITLE
+          SUPPORTED_COMPONENT_TYPES.EXTERNAL_LINK_TAB_TITLE,
+          {
+            inline: true,
+          }
         ),
       },
     ],

--- a/src/markdown-processor/marked-extentions/external-link-tab.js
+++ b/src/markdown-processor/marked-extentions/external-link-tab.js
@@ -47,7 +47,9 @@ const markedExternalLinkTab = () => {
             };
           }
         },
-        renderer: createRenderer(SUPPORTED_COMPONENT_TYPES.EXTERNAL_LINK_TAB),
+        renderer: createRenderer(SUPPORTED_COMPONENT_TYPES.EXTERNAL_LINK_TAB, {
+          inline: true,
+        }),
       },
     ],
   };

--- a/src/markdown-processor/marked-extentions/external-link-title.js
+++ b/src/markdown-processor/marked-extentions/external-link-title.js
@@ -52,7 +52,12 @@ const markedExternalLinkTitle = () => {
             };
           }
         },
-        renderer: createRenderer(SUPPORTED_COMPONENT_TYPES.EXTERNAL_LINK_TITLE),
+        renderer: createRenderer(
+          SUPPORTED_COMPONENT_TYPES.EXTERNAL_LINK_TITLE,
+          {
+            inline: true,
+          }
+        ),
       },
     ],
   };

--- a/src/markdown-processor/marked-extentions/internal-link-title.js
+++ b/src/markdown-processor/marked-extentions/internal-link-title.js
@@ -52,7 +52,12 @@ const markedInternalLinkTitle = () => {
             };
           }
         },
-        renderer: createRenderer(SUPPORTED_COMPONENT_TYPES.INTERNAL_LINK_TITLE),
+        renderer: createRenderer(
+          SUPPORTED_COMPONENT_TYPES.INTERNAL_LINK_TITLE,
+          {
+            inline: true,
+          }
+        ),
       },
     ],
   };

--- a/src/markdown-processor/marked-extentions/internal-link.js
+++ b/src/markdown-processor/marked-extentions/internal-link.js
@@ -45,7 +45,9 @@ const markedInternalLink = () => {
             };
           }
         },
-        renderer: createRenderer(SUPPORTED_COMPONENT_TYPES.INTERNAL_LINK),
+        renderer: createRenderer(SUPPORTED_COMPONENT_TYPES.INTERNAL_LINK, {
+          inline: true,
+        }),
       },
     ],
   };


### PR DESCRIPTION
 ## Problem

https://docs.google.com/document/d/1a5N6y_FUnX2v7OAqT1af8jfSrFgy2tL3gcBRU_Z9GXM/edit?tab=t.0#heading=h.1scu2ihrnpg2 (issue2 `轉換時客製語法的 HTML structure 可再優化`)

  Custom link syntax mixed with surrounding text produced malformed HTML:

  - `文字1@[連結](https://xxx)文字2` → `<p>文字1</p><a>連結</a>文字2<p></p>`
  - `@[連結](https://xxx)文字2` → `<p></p><a>連結</a>文字2<p></p>`

  The text before the custom syntax was split into its own `<p>`, and a trailing empty `<p></p>` was always appended after it.

  ## Root Cause

  All link extension renderers called `createRenderer()` without the  `{ inline: true }` option, causing `buildHTMLMarkup` to emit a `<div>` wrapper. When `html-react-parser` processes the marked.js HTML output, it enforces HTML content model rules - `<p>` cannot contain block-level `<div>` elements, so it auto-closes the `<p>` before the `<div>`, producing the split paragraphs and trailing empty `<p></p>`.

  ## Fix

  Pass `{ inline: true }` to `createRenderer()` for all five link extensions, switching the HTML wrapper from `<div>` to `<span>`. This produces a valid `<span>` wrapper that html-react-parser can nest inside `<p>` without auto-closing it.

  - `文字1@[連結](https://xxx)文字2` → `<p>文字1<a>連結</a>文字2</p>`
  - `@[連結](https://xxx)文字2` → `<p><a>連結</a>文字2</p>`