### PR TITLE
feat: add includeMathExtensions option to createMarkdownToReactParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ const content = seeMarkReactParse(markdown);
 
 | Option Name               | Type    | Default Value  | Description                                                        |
 | ------------------------- | ------- | -------------- | ------------------------------------------------------------------ |
+| includeMathExtensions     | boolean | true           | Include math (LaTeX/AsciiMath) and Nemeth extensions.              |
 | latexDelimiter            | string  | 'bracket'      | The delimiter for LaTeX expressions. Options: 'bracket', 'dollar'. |
 | documentFormat            | string  | 'inline'       | The format of the document. Options: 'inline', 'block'.            |
 | imageFiles                | object  | { [ID]: File } | A map of image IDs to File objects for image rendering.            |
@@ -122,6 +123,13 @@ const toc = createTableOfContents(markdown);
 ```
 
 `createTableOfContents` parses a markdown string and returns a flat array of all h1–h6 headings in document order. The `id` of each entry is generated with the same slugify logic used by the seemark's markdown parser, so IDs are guaranteed to match the `id` prop on rendered heading components.
+
+### Options
+
+| Option Name           | Type    | Default Value | Description                                                                                              |
+| --------------------- | ------- | ------------- | -------------------------------------------------------------------------------------------------------- |
+| includeMathExtensions | boolean | true          | Include math (LaTeX/AsciiMath) and Nemeth extensions. Must match the value used by the renderer.         |
+| latexDelimiter        | string  | 'bracket'     | The delimiter for LaTeX expressions. Must match the value used by the renderer. Options: 'bracket', 'dollar'. |
 
 ### Return value
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coseeing/see-mark",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A markdown parser for a11y",
   "main": "./lib/see-mark.cjs",
   "files": [

--- a/src/markdown-processor/markdown-processor.js
+++ b/src/markdown-processor/markdown-processor.js
@@ -17,7 +17,6 @@ import iframe from './marked-extentions/iframe';
 
 export const createMarkdownProcessor = (options = {}) => {
   const asciimathDelimiter = 'graveaccent';
-
   return markedProcessorFactory({
     latexDelimiter: options.latexDelimiter,
     asciimathDelimiter,
@@ -25,8 +24,7 @@ export const createMarkdownProcessor = (options = {}) => {
     imageFiles: options.imageFiles,
     shouldBuildImageObjectURL: options.shouldBuildImageObjectURL,
     extensions: [
-      math,
-      nemeth,
+      ...(options.includeMathExtensions !== false ? [math, nemeth] : []),
       alert,
       heading,
       internalLink,

--- a/src/markdown-processor/markdown-processor.test.js
+++ b/src/markdown-processor/markdown-processor.test.js
@@ -91,6 +91,42 @@ describe('markdownProcessor', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should not render math when includeMathExtensions is false', () => {
+    const markdownContent = '\\({{\\left( -3 \\right)}^{3}}\\)';
+    const options = {
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+      includeMathExtensions: false,
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const mathEl = getElementByType(container, SUPPORTED_COMPONENT_TYPES.MATH);
+
+    expect(mathEl).toBeNull();
+  });
+
+  it('should not render nemeth when includeMathExtensions is false', () => {
+    const markdownContent = '@⠁⠘⠆@';
+    const options = {
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+      includeMathExtensions: false,
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const mathEl = getElementByType(container, SUPPORTED_COMPONENT_TYPES.MATH);
+
+    expect(mathEl).toBeNull();
+  });
+
   it('should process alert', () => {
     const markdownContent = `> [!WARNING]\n> Critical content demanding immediate user attention due to potential risks.`;
     const options = {

--- a/src/parsers/options.js
+++ b/src/parsers/options.js
@@ -3,6 +3,7 @@ const DEFAULT_OPTINOS = {
   documentFormat: 'inline',
   imageFiles: null,
   shouldBuildImageObjectURL: false,
+  includeMathExtensions: true,
 };
 
 export const createMarkdownParserOptions = (options = DEFAULT_OPTINOS) => {

--- a/src/table-of-contents/create-table-of-contents.js
+++ b/src/table-of-contents/create-table-of-contents.js
@@ -34,6 +34,7 @@ function extractPlainText(inlineTokens = []) {
  *   Must match the value used by the markdown renderer so that math tokens
  *   inside headings are recognised and their text is correctly extracted.
  *   Defaults to 'bracket'.
+ * @param {boolean} [options.includeMathExtensions=true] - Whether to enable math extensions. Defaults to true.
  * @returns {{ level: number, id: string, text: string }[]}
  *
  * @example
@@ -46,6 +47,7 @@ function extractPlainText(inlineTokens = []) {
 const createTableOfContents = (markdown, options = {}) => {
   const { lexer } = createMarkdownProcessor({
     latexDelimiter: options.latexDelimiter ?? 'bracket',
+    includeMathExtensions: options.includeMathExtensions ?? true,
   });
   const tokens = lexer(markdown);
   const usedIds = new Map();


### PR DESCRIPTION
## Summary

  - Adds `includeMathExtensions` option to `createMarkdownToReactParser` (default: `true`)
  - When `false`, the `math` and `nemeth` marked extensions are excluded from the parser — useful for consumers who don't need math rendering and want a lighter parse
  - Default behavior is unchanged: math (LaTeX/AsciiMath) and Nemeth extensions are included as before
  - Documents the new option in README

  ## Usage

  To opt out of math/Nemeth rendering:

  ```js
  createMarkdownToReactParser({
    options: {
      includeMathExtensions: false,
      // ...other options
    },
    components,
  })