### PR TITLE
feat: add enableLatex, and enableAsciimath & enableNemeth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ const content = seeMarkReactParse(markdown);
 
 | Option Name               | Type    | Default Value  | Description                                                        |
 | ------------------------- | ------- | -------------- | ------------------------------------------------------------------ |
-| latexDelimiter            | string  | 'bracket'      | The delimiter for LaTeX expressions. Options: 'bracket', 'dollar'. |
+| enableLatex               | boolean | true           | When false, LaTeX expressions are not parsed as math.              |
+| enableAsciimath           | boolean | true           | When false, AsciiMath expressions are not parsed as math.          |
 | enableNemeth              | boolean | true           | When false, the Nemeth braille math extension is disabled and `@…@` syntax is not parsed. |
+| latexDelimiter            | string  | 'bracket'      | The delimiter for LaTeX expressions. Options: 'bracket', 'dollar'. |
 | documentFormat            | string  | 'inline'       | The format of the document. Options: 'inline', 'block'.            |
 | imageFiles                | object  | { [ID]: File } | A map of image IDs to File objects for image rendering.            |
 | shouldBuildImageObjectURL | boolean | false          | should build image object URL.                                     |
@@ -126,10 +128,12 @@ const toc = createTableOfContents(markdown);
 
 ### Options
 
-| Option Name    | Type    | Default Value | Description                                                                                      |
-| -------------- | ------- | ------------- | ------------------------------------------------------------------------------------------------ |
+| Option Name    | Type    | Default Value | Description                                                                                 |
+| -------------- | ------- | ------------- | ------------------------------------------------------------------------------------------- |
+| enableLatex    | boolean | true          | When false, LaTeX expressions are not parsed as math.                                       |
+| enableAsciimath | boolean | true         | When false, AsciiMath expressions are not parsed as math.                                   |
+| enableNemeth   | boolean | true          | When false, the Nemeth braille math extension is disabled and `@…@` syntax is not parsed.  |
 | latexDelimiter | string  | 'bracket'     | The delimiter for LaTeX expressions. Options: 'bracket', 'dollar'. Must match the renderer. |
-| enableNemeth   | boolean | true          | When false, the Nemeth braille math extension is disabled and `@…@` syntax is not parsed.   |
 
 ### Return value
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ const content = seeMarkReactParse(markdown);
 | Option Name               | Type    | Default Value  | Description                                                        |
 | ------------------------- | ------- | -------------- | ------------------------------------------------------------------ |
 | latexDelimiter            | string  | 'bracket'      | The delimiter for LaTeX expressions. Options: 'bracket', 'dollar'. |
+| enableNemeth              | boolean | true           | When false, the Nemeth braille math extension is disabled and `@…@` syntax is not parsed. |
 | documentFormat            | string  | 'inline'       | The format of the document. Options: 'inline', 'block'.            |
 | imageFiles                | object  | { [ID]: File } | A map of image IDs to File objects for image rendering.            |
 | shouldBuildImageObjectURL | boolean | false          | should build image object URL.                                     |
@@ -122,6 +123,13 @@ const toc = createTableOfContents(markdown);
 ```
 
 `createTableOfContents` parses a markdown string and returns a flat array of all h1–h6 headings in document order. The `id` of each entry is generated with the same slugify logic used by the seemark's markdown parser, so IDs are guaranteed to match the `id` prop on rendered heading components.
+
+### Options
+
+| Option Name    | Type    | Default Value | Description                                                                                      |
+| -------------- | ------- | ------------- | ------------------------------------------------------------------------------------------------ |
+| latexDelimiter | string  | 'bracket'     | The delimiter for LaTeX expressions. Options: 'bracket', 'dollar'. Must match the renderer. |
+| enableNemeth   | boolean | true          | When false, the Nemeth braille math extension is disabled and `@…@` syntax is not parsed.   |
 
 ### Return value
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coseeing/see-mark",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A markdown parser for a11y",
   "main": "./lib/see-mark.cjs",
   "files": [

--- a/src/markdown-processor/markdown-processor.js
+++ b/src/markdown-processor/markdown-processor.js
@@ -17,6 +17,7 @@ import iframe from './marked-extentions/iframe';
 
 export const createMarkdownProcessor = (options = {}) => {
   const asciimathDelimiter = 'graveaccent';
+  const enableNemeth = options.enableNemeth !== false;
 
   return markedProcessorFactory({
     latexDelimiter: options.latexDelimiter,
@@ -26,7 +27,7 @@ export const createMarkdownProcessor = (options = {}) => {
     shouldBuildImageObjectURL: options.shouldBuildImageObjectURL,
     extensions: [
       math,
-      nemeth,
+      ...(enableNemeth ? [nemeth] : []),
       alert,
       heading,
       internalLink,

--- a/src/markdown-processor/markdown-processor.js
+++ b/src/markdown-processor/markdown-processor.js
@@ -17,6 +17,9 @@ import iframe from './marked-extentions/iframe';
 
 export const createMarkdownProcessor = (options = {}) => {
   const asciimathDelimiter = 'graveaccent';
+
+  const enableLatex = options.enableLatex !== false;
+  const enableAsciimath = options.enableAsciimath !== false;
   const enableNemeth = options.enableNemeth !== false;
 
   return markedProcessorFactory({
@@ -25,8 +28,10 @@ export const createMarkdownProcessor = (options = {}) => {
     documentFormat: options.documentFormat,
     imageFiles: options.imageFiles,
     shouldBuildImageObjectURL: options.shouldBuildImageObjectURL,
+    enableLatex,
+    enableAsciimath,
     extensions: [
-      math,
+      ...(enableLatex || enableAsciimath ? [math] : []),
       ...(enableNemeth ? [nemeth] : []),
       alert,
       heading,

--- a/src/markdown-processor/markdown-processor.test.js
+++ b/src/markdown-processor/markdown-processor.test.js
@@ -91,6 +91,24 @@ describe('markdownProcessor', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should not parse nemeth braille when enableNemeth is false', () => {
+    const markdownContent = '@⠁⠘⠆@';
+    const options = {
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+      enableNemeth: false,
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const mathEl = getElementByType(container, SUPPORTED_COMPONENT_TYPES.MATH);
+
+    expect(mathEl).toBeNull();
+  });
+
   it('should process alert', () => {
     const markdownContent = `> [!WARNING]\n> Critical content demanding immediate user attention due to potential risks.`;
     const options = {

--- a/src/markdown-processor/markdown-processor.test.js
+++ b/src/markdown-processor/markdown-processor.test.js
@@ -94,10 +94,10 @@ describe('markdownProcessor', () => {
   it('should not parse nemeth braille when enableNemeth is false', () => {
     const markdownContent = '@⠁⠘⠆@';
     const options = {
+      enableNemeth: false,
       latexDelimiter: 'bracket',
       documentFormat: 'inline',
       imageFiles: {},
-      enableNemeth: false,
     };
 
     const result = markdownProcessor(markdownContent, options);
@@ -324,6 +324,85 @@ describe('markdownProcessor', () => {
 
     // snapshot matching
     expect(container).toMatchSnapshot();
+  });
+
+  it('should not parse latex when enableLatex is false', () => {
+    const markdownContent = '\\(a+b=c\\)';
+    const options = {
+      enableLatex: false,
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const mathEl = getElementByType(container, SUPPORTED_COMPONENT_TYPES.MATH);
+
+    expect(mathEl).toBeNull();
+  });
+
+  it('should not parse asciimath when enableAsciimath is false', () => {
+    const markdownContent = '`a+b=c`';
+    const options = {
+      enableAsciimath: false,
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const mathEl = getElementByType(container, SUPPORTED_COMPONENT_TYPES.MATH);
+
+    expect(mathEl).toBeNull();
+  });
+
+  it('should still parse latex when enableAsciimath is false', () => {
+    const markdownContent = '\\(a+b=c\\)';
+    const options = {
+      enableAsciimath: false,
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const mathEl = getElementByType(container, SUPPORTED_COMPONENT_TYPES.MATH);
+
+    expect(mathEl).toBeTruthy();
+
+    const payload = JSON.parse(
+      mathEl.getAttribute(SEE_MARK_PAYLOAD_DATA_ATTRIBUTES)
+    );
+
+    expect(payload.typed).toBe('latex');
+  });
+
+  it('should not parse any math when both enableLatex and enableAsciimath are false', () => {
+    const markdownContent = '\\(a+b=c\\) `a+b=c`';
+    const options = {
+      enableLatex: false,
+      enableAsciimath: false,
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const mathEl = getElementByType(container, SUPPORTED_COMPONENT_TYPES.MATH);
+
+    expect(mathEl).toBeNull();
   });
 
   it('should process image link', () => {

--- a/src/markdown-processor/marked-extentions/math.js
+++ b/src/markdown-processor/marked-extentions/math.js
@@ -51,7 +51,17 @@ const AsciiMath_delimiter_dict = {
  * @param {string} options.documentFormat - Document format for MathML display ('inline' or 'block')
  * @returns {Object} Marked extension object with math tokenizer and renderer
  */
-const markedMath = ({ latexDelimiter, asciimathDelimiter, documentFormat }) => {
+const markedMath = ({
+  enableLatex = true,
+  enableAsciimath = true,
+  latexDelimiter,
+  asciimathDelimiter,
+  documentFormat,
+}) => {
+  if (!enableLatex && !enableAsciimath) {
+    return { extensions: [] };
+  }
+
   const asciimath2mml = asciimath2mmlFactory({
     htmlMathDisplay: documentFormat,
   });
@@ -62,16 +72,21 @@ const markedMath = ({ latexDelimiter, asciimathDelimiter, documentFormat }) => {
 
   const latex_restring = `(?<=[^\\\\]?)${LaTeX_delimiter.start}(.*?[^\\\\])?${LaTeX_delimiter.end}`;
   const asciimath_restring = `(?<=[^\\\\]?)${AsciiMath_delimiter.start}(.*?[^\\\\])?${AsciiMath_delimiter.end}`;
-  const reTexMath = new RegExp(
-    `(.*?)(${latex_restring}|${asciimath_restring})`,
-    's'
-  );
 
   const latex_start_restring = `(?<=[^\\\\]?)${LaTeX_delimiter.start}`;
   const asciimath_start_restring = `(?<=[^\\\\]?)${AsciiMath_delimiter.start}`;
-  const reTexMath_start = new RegExp(
-    `${latex_start_restring}|${asciimath_start_restring}`
-  );
+
+  const matchPatterns = [
+    ...(enableLatex ? [latex_restring] : []),
+    ...(enableAsciimath ? [asciimath_restring] : []),
+  ];
+  const startPatterns = [
+    ...(enableLatex ? [latex_start_restring] : []),
+    ...(enableAsciimath ? [asciimath_start_restring] : []),
+  ];
+
+  const reTexMath = new RegExp(`(.*?)(${matchPatterns.join('|')})`, 's');
+  const reTexMath_start = new RegExp(startPatterns.join('|'));
 
   return {
     extensions: [

--- a/src/markdown-processor/marked-wrapper/marked-wrapper.js
+++ b/src/markdown-processor/marked-wrapper/marked-wrapper.js
@@ -3,6 +3,8 @@ import { Marked } from 'marked';
 import { createPositionTracker } from './position-tracker';
 
 const markedProcessorFactory = ({
+  enableLatex = true,
+  enableAsciimath = true,
   latexDelimiter,
   asciimathDelimiter,
   documentFormat,
@@ -25,6 +27,8 @@ const markedProcessorFactory = ({
   extensions.forEach((extension) => {
     marked.use(
       extension({
+        enableLatex,
+        enableAsciimath,
         latexDelimiter,
         asciimathDelimiter,
         documentFormat,

--- a/src/parsers/options.js
+++ b/src/parsers/options.js
@@ -1,9 +1,11 @@
 const DEFAULT_OPTINOS = {
+  enableLatex: true,
+  enableAsciimath: true,
+  enableNemeth: true,
   latexDelimiter: 'bracket',
   documentFormat: 'inline',
   imageFiles: null,
   shouldBuildImageObjectURL: false,
-  enableNemeth: true,
 };
 
 export const createMarkdownParserOptions = (options = DEFAULT_OPTINOS) => {

--- a/src/parsers/options.js
+++ b/src/parsers/options.js
@@ -3,6 +3,7 @@ const DEFAULT_OPTINOS = {
   documentFormat: 'inline',
   imageFiles: null,
   shouldBuildImageObjectURL: false,
+  enableNemeth: true,
 };
 
 export const createMarkdownParserOptions = (options = DEFAULT_OPTINOS) => {

--- a/src/table-of-contents/create-table-of-contents.js
+++ b/src/table-of-contents/create-table-of-contents.js
@@ -46,6 +46,7 @@ function extractPlainText(inlineTokens = []) {
 const createTableOfContents = (markdown, options = {}) => {
   const { lexer } = createMarkdownProcessor({
     latexDelimiter: options.latexDelimiter ?? 'bracket',
+    enableNemeth: options.enableNemeth !== false,
   });
   const tokens = lexer(markdown);
   const usedIds = new Map();

--- a/src/table-of-contents/create-table-of-contents.js
+++ b/src/table-of-contents/create-table-of-contents.js
@@ -45,8 +45,10 @@ function extractPlainText(inlineTokens = []) {
  */
 const createTableOfContents = (markdown, options = {}) => {
   const { lexer } = createMarkdownProcessor({
-    latexDelimiter: options.latexDelimiter ?? 'bracket',
+    enableLatex: options.enableLatex !== false,
+    enableAsciimath: options.enableAsciimath !== false,
     enableNemeth: options.enableNemeth !== false,
+    latexDelimiter: options.latexDelimiter ?? 'bracket',
   });
   const tokens = lexer(markdown);
   const usedIds = new Map();


### PR DESCRIPTION
## Summary

Adds three new boolean options to both `createMarkdownToReactParser` and `createTableOfContents` for selectively disabling math parsing extensions. All options default to `true` (existing behavior unchanged).

- `enableLatex` — controls LaTeX math parsing (`\(…\)`, `$…$`)
- `enableAsciimath` — controls AsciiMath parsing (backtick delimited)
- `enableNemeth` — controls the Nemeth braille math extension (`@…@` syntax)

When both `enableLatex` and `enableAsciimath` are `false`, the math extension is skipped entirely at the processor level. `math.js` also includes a defensive early return for the same case.

## Usage

```js
// Disable LaTeX only — AsciiMath still parsed
createMarkdownToReactParser({
  options: { enableLatex: false },
  components: {},
})(markdown);

// Disable Nemeth braille only
createMarkdownToReactParser({
  options: { enableNemeth: false },
  components: {},
})(markdown);

// Disable all math parsing
createMarkdownToReactParser({
  options: { enableLatex: false, enableAsciimath: false, enableNemeth: false },
  components: {},
})(markdown);

// Same options are available on createTableOfContents
createTableOfContents(markdown, { enableLatex: false, enableNemeth: false });
```
