### PR TITLE
feat: support http(s) URLs as image sources across image extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coseeing/see-mark",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A markdown parser for a11y",
   "main": "./lib/see-mark.cjs",
   "files": [

--- a/src/markdown-processor/markdown-processor.test.js
+++ b/src/markdown-processor/markdown-processor.test.js
@@ -486,6 +486,39 @@ describe('markdownProcessor', () => {
     expect(mathEl).toBeNull();
   });
 
+  it('should process image with URL as imageId', () => {
+    const markdownContent = `![alt text](https://example.com/image.jpg)`;
+    const options = {
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const imageContainer = getElementByType(
+      container,
+      SUPPORTED_COMPONENT_TYPES.IMAGE
+    );
+
+    expect(imageContainer).toBeTruthy();
+
+    const payloadString = imageContainer.getAttribute(
+      SEE_MARK_PAYLOAD_DATA_ATTRIBUTES
+    );
+
+    const payload = JSON.parse(payloadString);
+
+    expect(payload).toEqual({
+      alt: 'alt text',
+      imageId: 'https://example.com/image.jpg',
+      position: { start: 0, end: 42 },
+      source: 'https://example.com/image.jpg',
+    });
+  });
+
   it('should process image link', () => {
     const markdownContent = `![alt text](image-123)((https://example.com/target))`;
     const options = {
@@ -517,6 +550,40 @@ describe('markdownProcessor', () => {
       alt: 'alt text',
       imageId: 'image-123',
       position: { start: 0, end: 52 },
+      source: 'https://example.com/image.jpg',
+      target: 'https://example.com/target',
+    });
+  });
+
+  it('should process image link with URL as imageId', () => {
+    const markdownContent = `![alt text](https://example.com/image.jpg)((https://example.com/target))`;
+    const options = {
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const imageLinkContainer = getElementByType(
+      container,
+      SUPPORTED_COMPONENT_TYPES.IMAGE_LINK
+    );
+
+    expect(imageLinkContainer).toBeTruthy();
+
+    const payloadString = imageLinkContainer.getAttribute(
+      SEE_MARK_PAYLOAD_DATA_ATTRIBUTES
+    );
+
+    const payload = JSON.parse(payloadString);
+
+    expect(payload).toEqual({
+      alt: 'alt text',
+      imageId: 'https://example.com/image.jpg',
+      position: { start: 0, end: 72 },
       source: 'https://example.com/image.jpg',
       target: 'https://example.com/target',
     });
@@ -558,6 +625,40 @@ describe('markdownProcessor', () => {
     });
   });
 
+  it('should process image display with URL as imageId', () => {
+    const markdownContent = `![alt text][[Display caption]](https://example.com/image.jpg)`;
+    const options = {
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const imageDisplayContainer = getElementByType(
+      container,
+      SUPPORTED_COMPONENT_TYPES.IMAGE_DISPLAY
+    );
+
+    expect(imageDisplayContainer).toBeTruthy();
+
+    const payloadString = imageDisplayContainer.getAttribute(
+      SEE_MARK_PAYLOAD_DATA_ATTRIBUTES
+    );
+
+    const payload = JSON.parse(payloadString);
+
+    expect(payload).toEqual({
+      alt: 'alt text',
+      display: 'Display caption',
+      imageId: 'https://example.com/image.jpg',
+      position: { start: 0, end: 61 },
+      source: 'https://example.com/image.jpg',
+    });
+  });
+
   it('should process image display link', () => {
     const markdownContent = `![alt text][[Display caption]](image-789)((https://example.com/details))`;
     const options = {
@@ -591,6 +692,41 @@ describe('markdownProcessor', () => {
       imageId: 'image-789',
       position: { start: 0, end: 72 },
       source: 'https://example.com/image3.jpg',
+      target: 'https://example.com/details',
+    });
+  });
+
+  it('should process image display link with URL as imageId', () => {
+    const markdownContent = `![alt text][[Display caption]](https://example.com/image.jpg)((https://example.com/details))`;
+    const options = {
+      latexDelimiter: 'bracket',
+      documentFormat: 'inline',
+      imageFiles: {},
+    };
+
+    const result = markdownProcessor(markdownContent, options);
+
+    const container = createDOMFromHTML(result);
+
+    const imageDisplayLinkContainer = getElementByType(
+      container,
+      SUPPORTED_COMPONENT_TYPES.IMAGE_DISPLAY_LINK
+    );
+
+    expect(imageDisplayLinkContainer).toBeTruthy();
+
+    const payloadString = imageDisplayLinkContainer.getAttribute(
+      SEE_MARK_PAYLOAD_DATA_ATTRIBUTES
+    );
+
+    const payload = JSON.parse(payloadString);
+
+    expect(payload).toEqual({
+      alt: 'alt text',
+      display: 'Display caption',
+      imageId: 'https://example.com/image.jpg',
+      position: { start: 0, end: 92 },
+      source: 'https://example.com/image.jpg',
       target: 'https://example.com/details',
     });
   });

--- a/src/markdown-processor/marked-extentions/image-display-link.js
+++ b/src/markdown-processor/marked-extentions/image-display-link.js
@@ -65,10 +65,13 @@ const markedImageDisplayLink = ({ imageFiles, shouldBuildImageObjectURL }) => {
             const target = match[4];
 
             try {
-              const imageFile = imageFiles[imageId];
-              const source = shouldBuildImageObjectURL
-                ? blobUrlManager(imageId, imageFile)
-                : imageFile;
+              const isUrl = /^https?:/i.test(imageId);
+              const imageFile = isUrl ? null : imageFiles[imageId];
+              const source = isUrl
+                ? imageId
+                : shouldBuildImageObjectURL
+                  ? blobUrlManager(imageId, imageFile)
+                  : imageFile;
 
               return {
                 type: SUPPORTED_COMPONENT_TYPES.IMAGE_DISPLAY_LINK,

--- a/src/markdown-processor/marked-extentions/image-display.js
+++ b/src/markdown-processor/marked-extentions/image-display.js
@@ -59,10 +59,13 @@ const markedImageDisplay = ({ imageFiles, shouldBuildImageObjectURL }) => {
             const imageId = match[3];
 
             try {
-              const imageFile = imageFiles[imageId];
-              const source = shouldBuildImageObjectURL
-                ? blobUrlManager(imageId, imageFile)
-                : imageFile;
+              const isUrl = /^https?:/i.test(imageId);
+              const imageFile = isUrl ? null : imageFiles[imageId];
+              const source = isUrl
+                ? imageId
+                : shouldBuildImageObjectURL
+                  ? blobUrlManager(imageId, imageFile)
+                  : imageFile;
 
               return {
                 type: SUPPORTED_COMPONENT_TYPES.IMAGE_DISPLAY,

--- a/src/markdown-processor/marked-extentions/image-link.js
+++ b/src/markdown-processor/marked-extentions/image-link.js
@@ -59,10 +59,13 @@ const markedImageLink = ({ imageFiles, shouldBuildImageObjectURL }) => {
             const target = match[3];
 
             try {
-              const imageFile = imageFiles[imageId];
-              const source = shouldBuildImageObjectURL
-                ? blobUrlManager(imageId, imageFile)
-                : imageFile;
+              const isUrl = /^https?:/i.test(imageId);
+              const imageFile = isUrl ? null : imageFiles[imageId];
+              const source = isUrl
+                ? imageId
+                : shouldBuildImageObjectURL
+                  ? blobUrlManager(imageId, imageFile)
+                  : imageFile;
 
               return {
                 type: SUPPORTED_COMPONENT_TYPES.IMAGE_LINK,

--- a/src/markdown-processor/marked-extentions/image.js
+++ b/src/markdown-processor/marked-extentions/image.js
@@ -22,11 +22,14 @@ const markedImage = ({ imageFiles, shouldBuildImageObjectURL }) => {
       extractMeta(token) {
         const alt = token.text;
         const imageId = token.href;
-        const imageFile = imageFiles[imageId];
+        const isUrl = /^https?:/i.test(imageId);
+        const imageFile = isUrl ? null : imageFiles[imageId];
 
-        const source = shouldBuildImageObjectURL
-          ? blobUrlManager(imageId, imageFile)
-          : imageFile;
+        const source = isUrl
+          ? imageId
+          : shouldBuildImageObjectURL
+            ? blobUrlManager(imageId, imageFile)
+            : imageFile;
 
         return { alt, imageId, source };
       },


### PR DESCRIPTION
## Issues

### 1. 使用 URL 作為 image source 時出現 `createObjectURL` error

當 image 相關語法使用 URL 作為 source（而非自行上傳的圖）時，會拋出 `TypeError: Failed to execute 'createObjectURL' on 'URL': Overload resolution failed.` error。

雖然 [onError](https://github.com/coseeing/SeeMark/blob/main/src/markdown-processor/marked-extentions/image.js#L34-L41) 處理得當，component 仍可正常 render，但覺得仍應該修正這個 error。

例如：
```
![貓咪 alt](https://s.yimg.com/cv/apiv2/ysun01/cat.jpg)
```
<img width="1846" height="919" alt="Screenshot 2026-05-20 at 18 40 03" src="https://github.com/user-attachments/assets/64439564-58e9-422e-809a-0b466a0e5557" />

### 2. 匯出檔案時，URL source 的圖片遺失

由於我們不會把 URL 當作 source 的圖加進 [imageFiles](https://github.com/coseeing/Access8MathWeb/blob/0a58576f40f23cf5e2fed49e4275a6a97df39c0c/src/components/edit-icons-tab.js#L57-L64) 裡，匯出時 [seemark 找不到圖的 source](https://github.com/coseeing/SeeMark/blob/main/src/markdown-processor/marked-extentions/image.js#L29)，導致圖片無法正確顯示在匯出的 template 中。

<img width="1846" height="919" alt="Screenshot 2026-05-20 at 18 42 54" src="https://github.com/user-attachments/assets/3ee0e18e-7ef4-41c8-b3bc-2813428737db" />


## Changes
  - `image.js`, `image-link.js`, `image-display.js`, `image-display-link.js`: when `imageId` matches `^https?:`, skip the `imageFiles` lookup and use the URL itself as `source`.
  - Added URL-`imageId` test cases for all four image extensions in `markdown-processor.test.js`.